### PR TITLE
Remove left-pad and solidity-sha3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ethpm-registry",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,28 +8,13 @@
       "version": "6.0.85",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
       "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA==",
-      "dev": true
-    },
-    "accepts": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
-      "requires": {
-        "mime-types": "2.1.16",
-        "negotiator": "0.6.1"
-      }
+      "optional": true
     },
     "acorn": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
       "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
-      "dev": true
-    },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
     "ajv": {
@@ -38,8 +23,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "amdefine": {
@@ -49,34 +34,11 @@
       "dev": true,
       "optional": true
     },
-    "ansi-align": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
-    "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "optional": true,
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
-      }
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "aproba": {
       "version": "1.1.2",
@@ -90,36 +52,9 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "optional": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "optional": true
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "optional": true
-    },
-    "arraybuffer.slice": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
-      "dev": true
     },
     "asap": {
       "version": "2.0.6",
@@ -139,9 +74,9 @@
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert-plus": {
@@ -150,22 +85,10 @@
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
-    "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-      "dev": true
-    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "optional": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -185,558 +108,10 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
-    "babel-cli": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
-      "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-polyfill": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "chokidar": "1.7.0",
-        "commander": "2.11.0",
-        "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.6",
-        "v8flags": "2.1.1"
-      }
-    },
-    "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
-    },
-    "babel-core": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-generator": "6.25.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
-        "source-map": "0.5.6"
-      }
-    },
-    "babel-generator": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.6",
-        "trim-right": "1.0.1"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "requires": {
-        "babel-helper-define-map": "6.24.1",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "regexpu-core": "2.0.0"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "requires": {
-        "regenerator-transform": "0.9.11"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-polyfill": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
-    },
-    "babel-register": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-runtime": "6.25.0",
-        "core-js": "2.4.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
-      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
-      "requires": {
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
-      }
-    },
-    "babel-template": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.17.4",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
-      "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w=",
-      "dev": true
-    },
-    "base32.js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
-      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
-      "dev": true
-    },
-    "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
-      "dev": true
-    },
-    "base64id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -746,7 +121,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       },
       "dependencies": {
         "tweetnacl": {
@@ -758,33 +133,15 @@
         }
       }
     },
-    "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true,
-      "requires": {
-        "callsite": "1.0.0"
-      }
-    },
-    "bignumber.js": {
-      "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-    },
     "binary": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "dev": true,
       "requires": {
-        "buffers": "0.1.1",
-        "chainsaw": "0.1.0"
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
       }
-    },
-    "binary-extensions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
-      "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
-      "optional": true
     },
     "bindings": {
       "version": "1.3.0",
@@ -798,7 +155,7 @@
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "bl": {
@@ -807,7 +164,7 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "blakejs": {
@@ -816,81 +173,19 @@
       "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
       "dev": true
     },
-    "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-      "dev": true
-    },
     "bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
     },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "borc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.0.2.tgz",
-      "integrity": "sha1-jq4aTVmc/f38n6hXy7ppyQ6DKR8=",
-      "dev": true,
-      "requires": {
-        "bignumber.js": "3.0.1",
-        "commander": "2.11.0",
-        "ieee754": "1.1.8",
-        "json-text-sequence": "0.1.1"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-3.0.1.tgz",
-          "integrity": "sha1-gHZS0Q453jfp40lyR+3HmLt0b3Y=",
-          "dev": true
-        }
-      }
-    },
-    "boxen": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
-      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
-      "dev": true,
-      "requires": {
-        "ansi-align": "1.1.0",
-        "camelcase": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-boxes": "1.0.0",
-        "filled-array": "1.1.0",
-        "object-assign": "4.1.1",
-        "repeating": "2.0.1",
-        "string-width": "1.0.2",
-        "widest-line": "1.0.0"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "optional": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
       }
     },
     "brfs": {
@@ -899,10 +194,10 @@
       "integrity": "sha1-22ddb16SPm3wh/ylhZyQkKrtMhY=",
       "dev": true,
       "requires": {
-        "quote-stream": "1.0.2",
-        "resolve": "1.4.0",
-        "static-module": "1.4.0",
-        "through2": "2.0.3"
+        "quote-stream": "^1.0.1",
+        "resolve": "^1.1.5",
+        "static-module": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "brorand": {
@@ -923,20 +218,11 @@
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.0",
-        "inherits": "2.0.3"
-      }
-    },
-    "browserify-sha3": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.2.tgz",
-      "integrity": "sha1-JWzMx+2XLEqA60mcgqrMy+5sCkU=",
-      "dev": true,
-      "requires": {
-        "js-sha3": "0.5.5"
+        "buffer-xor": "^1.0.2",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-zlib": {
@@ -945,7 +231,7 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       },
       "dependencies": {
         "pako": {
@@ -954,24 +240,6 @@
           "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
           "dev": true
         }
-      }
-    },
-    "browserify-zlib-next": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-zlib-next/-/browserify-zlib-next-1.0.1.tgz",
-      "integrity": "sha1-iAQDhotPYmLw8+rPBGmav58Hb58=",
-      "dev": true,
-      "requires": {
-        "pako": "1.0.5"
-      }
-    },
-    "bs58": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
-      "integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
-      "dev": true,
-      "requires": {
-        "base-x": "1.1.0"
       }
     },
     "buffer-equal": {
@@ -998,34 +266,10 @@
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-      "dev": true
-    },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-      "dev": true
-    },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
     "caseless": {
@@ -1034,24 +278,13 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "1.0.2",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
-      }
-    },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "dev": true,
       "requires": {
-        "traverse": "0.3.9"
+        "traverse": ">=0.3.0 <0.4"
       },
       "dependencies": {
         "traverse": {
@@ -1060,35 +293,6 @@
           "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
           "dev": true
         }
-      }
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
-    },
-    "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "optional": true,
-      "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.2",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -1103,9 +307,9 @@
       "integrity": "sha1-8UFOePpGb+l6fOnNbAOJKZO+8wc=",
       "dev": true,
       "requires": {
-        "multibase": "0.3.4",
-        "multicodec": "0.1.8",
-        "multihashes": "0.4.5"
+        "multibase": "~0.3.4",
+        "multicodec": "~0.1.7",
+        "multihashes": "~0.4.4"
       },
       "dependencies": {
         "base-x": {
@@ -1114,7 +318,7 @@
           "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "bs58": {
@@ -1123,7 +327,7 @@
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
-            "base-x": "3.0.2"
+            "base-x": "^3.0.2"
           }
         },
         "multihashes": {
@@ -1132,8 +336,8 @@
           "integrity": "sha1-mwU8Uf3HTXce3eIOG8kdS77D+mk=",
           "dev": true,
           "requires": {
-            "bs58": "4.0.1",
-            "varint": "5.0.0"
+            "bs58": "^4.0.0",
+            "varint": "^5.0.0"
           }
         }
       }
@@ -1144,25 +348,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true
-    },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "co": {
@@ -1183,7 +370,7 @@
       "integrity": "sha1-gFHaYILocgiq3VK9gXJ1t8gDUAk=",
       "dev": true,
       "requires": {
-        "duplexer": "0.0.4"
+        "duplexer": "~0.0.2"
       },
       "dependencies": {
         "duplexer": {
@@ -1200,36 +387,14 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-    },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
-      "dev": true
-    },
-    "component-emitter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
-      "dev": true
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
-      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -1237,26 +402,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      }
-    },
-    "configstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-      "dev": true,
-      "requires": {
-        "dot-prop": "3.0.0",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "os-tmpdir": "1.0.2",
-        "osenv": "0.1.4",
-        "uuid": "2.0.3",
-        "write-file-atomic": "1.3.4",
-        "xdg-basedir": "2.0.0"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-control-strings": {
@@ -1265,55 +413,11 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
-    "content": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/content/-/content-3.0.5.tgz",
-      "integrity": "sha512-MQVYZuNnm5N0xalwtRGlZrcKFwgE6VKXCEh3XkCeoWUo3gL5BS52UiqswRvAwQW1ocfdCNkEKI5uy0pNGax+IQ==",
-      "dev": true,
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
-    },
-    "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "1.0.0"
-      }
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "create-hash": {
       "version": "1.1.3",
@@ -1321,10 +425,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.8"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -1333,12 +437,12 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cryptiles": {
@@ -1347,7 +451,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1356,7 +460,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "hoek": {
@@ -1378,44 +482,13 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
-    },
-    "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "dev": true,
-      "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
       }
@@ -1438,67 +511,11 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
-      "dev": true
-    },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
     "detect-node": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
       "dev": true
-    },
-    "dexie": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-1.5.1.tgz",
-      "integrity": "sha1-rDrVoOuvfm5Cdg21hxBBjUp1ZiQ=",
-      "dev": true
-    },
-    "dicer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14",
-        "streamsearch": "0.1.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
     },
     "diff": {
       "version": "3.2.0",
@@ -1506,24 +523,15 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
-    "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true,
-      "requires": {
-        "is-obj": "1.0.1"
-      }
-    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.0.6",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6"
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
       }
     },
     "duplexer": {
@@ -1538,7 +546,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "isarray": {
@@ -1553,10 +561,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1574,9 +582,9 @@
       "dev": true,
       "requires": {
         "end-of-stream": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -1585,7 +593,7 @@
           "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
           "dev": true,
           "requires": {
-            "once": "1.3.3"
+            "once": "~1.3.0"
           }
         },
         "once": {
@@ -1594,7 +602,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         }
       }
@@ -1606,7 +614,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.0"
+        "jsbn": "~0.1.0"
       }
     },
     "elliptic": {
@@ -1615,13 +623,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "end-of-stream": {
@@ -1630,120 +638,14 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
-      }
-    },
-    "engine.io": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz",
-      "integrity": "sha1-d7zhK4Dl1gQpM3/sOw2vaR68kAM=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.3",
-        "base64id": "1.0.0",
-        "cookie": "0.3.1",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.2",
-        "ws": "1.1.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
-    "engine.io-client": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.4.tgz",
-      "integrity": "sha1-n+hd7iWFPKa6viW9KtaHEIY+kcI=",
-      "dev": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.2",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "1.1.2",
-        "xmlhttprequest-ssl": "1.5.3",
-        "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        },
-        "ws": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
-          "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
-          "dev": true,
-          "requires": {
-            "options": "0.0.6",
-            "ultron": "1.0.2"
-          }
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
-      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
-      "dev": true,
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary": "0.1.7",
-        "wtf-8": "1.0.0"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "0.2.1"
+        "once": "^1.4.0"
       }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.3.3",
@@ -1751,10 +653,10 @@
       "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
       "dev": true,
       "requires": {
-        "esprima": "1.1.1",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
+        "esprima": "~1.1.1",
+        "estraverse": "~1.5.0",
+        "esutils": "~1.0.0",
+        "source-map": "~0.1.33"
       },
       "dependencies": {
         "esutils": {
@@ -1770,7 +672,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1787,11 +689,6 @@
       "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=",
       "dev": true
     },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-    },
     "ethjs-abi": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
@@ -1803,32 +700,39 @@
       }
     },
     "ethpm": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/ethpm/-/ethpm-0.0.10.tgz",
-      "integrity": "sha1-zn7X7RlV6cO/ouR6kFEYonrWbMQ=",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/ethpm/-/ethpm-0.0.15.tgz",
+      "integrity": "sha512-nf6Im5HIN8WGqmpaxLnIQl73C5aY2K6foz6PDi0WoSaMd00TapeH8O5y608YICudOGDLCGGyRd1wqf078LoZJA==",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "ethpm-spec": "1.0.1",
-        "fs-extra": "1.0.0",
-        "glob": "7.1.2",
-        "ipfs": "0.18.0",
-        "ipfs-api": "11.2.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.4",
-        "node-dir": "0.1.17",
-        "promisify-node": "0.4.0",
-        "semver": "5.4.1",
-        "wget-improved": "1.5.0"
+        "async": "^2.1.2",
+        "ethpm-spec": "^1.0.1",
+        "fs-extra": "^1.0.0",
+        "glob": "^7.1.1",
+        "ipfs-mini": "^1.1.2",
+        "jsonschema": "^1.1.1",
+        "lodash": "^4.17.1",
+        "node-dir": "^0.1.16",
+        "promisify-node": "^0.4.0",
+        "semver": "^5.3.0",
+        "wget-improved": "^1.4.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.17.14"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.15",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+              "dev": true
+            }
           }
         },
         "fs-extra": {
@@ -1837,9 +741,9 @@
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         }
       }
@@ -1850,7 +754,7 @@
       "integrity": "sha1-rTwJrgSSrT0+x7lLf1/YBX1N65E=",
       "dev": true,
       "requires": {
-        "json-schema-to-markdown": "1.0.3"
+        "json-schema-to-markdown": "^1.0.3"
       }
     },
     "evp_bytestokey": {
@@ -1859,25 +763,7 @@
       "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3"
-      }
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "optional": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "optional": true,
-      "requires": {
-        "fill-range": "2.2.3"
+        "create-hash": "^1.1.1"
       }
     },
     "expand-template": {
@@ -1892,15 +778,6 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "optional": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
@@ -1913,10 +790,10 @@
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
-        "foreach": "2.0.5",
+        "acorn": "^5.0.0",
+        "foreach": "^2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "1.0.11"
+        "object-keys": "^1.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -1927,60 +804,11 @@
         }
       }
     },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "optional": true
-    },
-    "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "optional": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "filled-array": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
-      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
-      "dev": true
-    },
-    "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
-      "requires": {
-        "locate-path": "2.0.0"
-      }
-    },
     "flatmap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
       "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ=",
       "dev": true
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "optional": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "optional": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -2000,9 +828,9 @@
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
@@ -2010,828 +838,15 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
       "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
       }
-    },
-    "fs-pull-blob-store": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fs-pull-blob-store/-/fs-pull-blob-store-0.3.0.tgz",
-      "integrity": "sha1-tIl1e0RFzcqOLqs1qXRKRPNFOxY=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1",
-        "pull-defer": "0.2.2",
-        "pull-file": "0.5.0",
-        "pull-stream": "3.6.0",
-        "pull-write-file": "0.2.4"
-      },
-      "dependencies": {
-        "pull-file": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
-          "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
-          "dev": true,
-          "requires": {
-            "pull-utf8-decoder": "1.0.2"
-          }
-        }
-      }
-    },
-    "fs-readdir-recursive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "optional": true,
-      "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fstream": {
       "version": "0.1.31",
@@ -2839,10 +854,10 @@
       "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "3.0.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.2.8"
+        "graceful-fs": "~3.0.2",
+        "inherits": "~2.0.0",
+        "mkdirp": "0.5",
+        "rimraf": "2"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2851,7 +866,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "^1.1.0"
           }
         }
       }
@@ -2868,14 +883,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.1.2",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "generate-function": {
@@ -2890,20 +905,8 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
-    },
-    "get-browser-rtc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.0.2.tgz",
-      "integrity": "sha1-u81AyEUaftTvXDc7gWmkCd0dEdk=",
-      "dev": true
-    },
-    "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -2911,7 +914,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2932,23 +935,14 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "optional": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-escape": {
@@ -2957,30 +951,17 @@
       "integrity": "sha1-nCf3gh7RwTd1gvPv2VWOP2dWKO0=",
       "dev": true
     },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "2.0.1"
-      }
-    },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-    },
     "go-ipfs-dep": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.4.4.tgz",
       "integrity": "sha1-IoMG/R2QgblkFFhPgZvJswHSj1Q=",
       "dev": true,
       "requires": {
-        "go-platform": "1.0.0",
-        "gunzip-maybe": "1.4.1",
-        "request": "2.81.0",
-        "tar-fs": "1.15.3",
-        "unzip": "0.1.11"
+        "go-platform": "^1.0.0",
+        "gunzip-maybe": "^1.3.1",
+        "request": "^2.75.0",
+        "tar-fs": "^1.13.2",
+        "unzip": "^0.1.11"
       }
     },
     "go-platform": {
@@ -2988,40 +969,6 @@
       "resolved": "https://registry.npmjs.org/go-platform/-/go-platform-1.0.0.tgz",
       "integrity": "sha1-sF/2uSdAB9JGsWQjXwP39qWWJsc=",
       "dev": true
-    },
-    "got": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer2": "0.1.4",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "node-status-codes": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "timed-out": "3.1.3",
-        "unzip-response": "1.0.2",
-        "url-parse-lax": "1.0.0"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3"
-          }
-        }
-      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -3046,314 +993,13 @@
       "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
       "dev": true,
       "requires": {
-        "browserify-zlib": "0.1.4",
-        "is-deflate": "1.0.0",
-        "is-gzip": "1.0.0",
-        "peek-stream": "1.1.2",
-        "pumpify": "1.3.5",
-        "through2": "2.0.3"
+        "browserify-zlib": "^0.1.4",
+        "is-deflate": "^1.0.0",
+        "is-gzip": "^1.0.0",
+        "peek-stream": "^1.1.0",
+        "pumpify": "^1.3.3",
+        "through2": "^2.0.3"
       }
-    },
-    "hapi": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-15.2.0.tgz",
-      "integrity": "sha1-VwTKLAS2OGwDyvnukB8d4IAxbSM=",
-      "dev": true,
-      "requires": {
-        "accept": "2.1.2",
-        "ammo": "2.0.2",
-        "boom": "4.0.0",
-        "call": "3.0.3",
-        "catbox": "7.1.2",
-        "catbox-memory": "2.0.3",
-        "cryptiles": "3.0.2",
-        "heavy": "4.0.2",
-        "hoek": "4.0.2",
-        "iron": "4.0.3",
-        "items": "2.1.1",
-        "joi": "9.0.4",
-        "mimos": "3.0.3",
-        "podium": "1.2.3",
-        "shot": "3.3.2",
-        "statehood": "5.0.0",
-        "subtext": "4.3.0",
-        "topo": "2.0.2"
-      },
-      "dependencies": {
-        "accept": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/accept/-/accept-2.1.2.tgz",
-          "integrity": "sha1-VRh07Y8saLJwe/8qsl/hNT5GHWs=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0",
-            "hoek": "4.0.2"
-          }
-        },
-        "ammo": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.2.tgz",
-          "integrity": "sha1-NmxV97xPLyQhjtOk3UuN8TXC5so=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0",
-            "hoek": "4.0.2"
-          }
-        },
-        "boom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.0.0.tgz",
-          "integrity": "sha1-fllGkmTq3bdP7fvBsWUk1pppRXc=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.0.2"
-          }
-        },
-        "call": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/call/-/call-3.0.3.tgz",
-          "integrity": "sha1-5HSN27t/Qa5AzuBV+LJwtzO/fI0=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0",
-            "hoek": "4.0.2"
-          }
-        },
-        "catbox": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.1.2.tgz",
-          "integrity": "sha1-RnIbHJmWdRP9e36UUXBqBe3+1a0=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0",
-            "hoek": "4.0.2",
-            "joi": "9.0.4"
-          }
-        },
-        "catbox-memory": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-2.0.3.tgz",
-          "integrity": "sha1-36qcFj+tND2a3W18H9x7Qps2nDg=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.0.2"
-          }
-        },
-        "cryptiles": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.0.2.tgz",
-          "integrity": "sha1-7M30qFuHVPFdC1Mg1Kt41A0PokQ=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0"
-          }
-        },
-        "heavy": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/heavy/-/heavy-4.0.2.tgz",
-          "integrity": "sha1-27Zs2l8BellPxsgwHfaZnqjVM/A=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0",
-            "hoek": "4.0.2",
-            "joi": "9.0.4"
-          }
-        },
-        "hoek": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.0.2.tgz",
-          "integrity": "sha1-e5afTIoa+KOMosZmxmv6bEL+LN0=",
-          "dev": true
-        },
-        "iron": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/iron/-/iron-4.0.3.tgz",
-          "integrity": "sha1-DA0yUmYdihxhS+2e07B32A6g/Xg=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0",
-            "cryptiles": "3.0.2",
-            "hoek": "4.0.2"
-          }
-        },
-        "items": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-          "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
-          "dev": true
-        },
-        "joi": {
-          "version": "9.0.4",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-9.0.4.tgz",
-          "integrity": "sha1-iNZIkJFavrEnzXVwJxFtUN8+aN8=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.0.2",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "moment": "2.14.1",
-            "topo": "2.0.2"
-          },
-          "dependencies": {
-            "isemail": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-              "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
-              "dev": true
-            },
-            "moment": {
-              "version": "2.14.1",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
-              "integrity": "sha1-s1snxH5X7S3ccAU9awe+zbKRdBw=",
-              "dev": true
-            }
-          }
-        },
-        "mimos": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
-          "integrity": "sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.0.2",
-            "mime-db": "1.23.0"
-          },
-          "dependencies": {
-            "mime-db": {
-              "version": "1.23.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-              "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
-              "dev": true
-            }
-          }
-        },
-        "podium": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/podium/-/podium-1.2.3.tgz",
-          "integrity": "sha1-XJW3zC9ch90yTgrUqTY6xi1ms3E=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.0.2",
-            "items": "2.1.1",
-            "joi": "9.0.4"
-          }
-        },
-        "shot": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/shot/-/shot-3.3.2.tgz",
-          "integrity": "sha1-aRwmEXWd7MIEh7INJcwpnznl+bc=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.0.2",
-            "joi": "9.0.4"
-          }
-        },
-        "statehood": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.0.tgz",
-          "integrity": "sha1-ziKFqr6uOYrofLunRhhLdZm4+jE=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0",
-            "cryptiles": "3.0.2",
-            "hoek": "4.0.2",
-            "iron": "4.0.3",
-            "items": "2.1.1",
-            "joi": "9.0.4"
-          }
-        },
-        "subtext": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/subtext/-/subtext-4.3.0.tgz",
-          "integrity": "sha1-36yQSS7DVmn9bgDG5dk4sG18z7s=",
-          "dev": true,
-          "requires": {
-            "boom": "4.0.0",
-            "content": "3.0.2",
-            "hoek": "4.0.2",
-            "pez": "2.1.2",
-            "wreck": "10.0.0"
-          },
-          "dependencies": {
-            "content": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/content/-/content-3.0.2.tgz",
-              "integrity": "sha1-8di0w6uyHqTA4hc/Q6wCKaTtbRw=",
-              "dev": true,
-              "requires": {
-                "boom": "4.0.0"
-              }
-            },
-            "pez": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/pez/-/pez-2.1.2.tgz",
-              "integrity": "sha1-0dEjcXkqVYluI+IeUJxAle0IHbI=",
-              "dev": true,
-              "requires": {
-                "b64": "3.0.2",
-                "boom": "4.0.0",
-                "content": "3.0.2",
-                "hoek": "4.0.2",
-                "nigel": "2.0.2"
-              },
-              "dependencies": {
-                "b64": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/b64/-/b64-3.0.2.tgz",
-                  "integrity": "sha1-ep1gRmrfe43hFMvfZRpf38yQiU0=",
-                  "dev": true
-                },
-                "nigel": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.2.tgz",
-                  "integrity": "sha1-k6GGb7DFLYc5CqdeKxYfS1x15bE=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "4.0.2",
-                    "vise": "2.0.2"
-                  },
-                  "dependencies": {
-                    "vise": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/vise/-/vise-2.0.2.tgz",
-                      "integrity": "sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=",
-                      "dev": true,
-                      "requires": {
-                        "hoek": "4.0.2"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "wreck": {
-              "version": "10.0.0",
-              "resolved": "https://registry.npmjs.org/wreck/-/wreck-10.0.0.tgz",
-              "integrity": "sha1-mKuIL4XhalJjMlB/EB9aeEEWIng=",
-              "dev": true,
-              "requires": {
-                "boom": "4.0.0",
-                "hoek": "4.0.2"
-              }
-            }
-          }
-        },
-        "topo": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.0.2"
-          }
-        }
-      }
-    },
-    "hapi-set-header": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hapi-set-header/-/hapi-set-header-1.0.2.tgz",
-      "integrity": "sha1-KvrgAsZxnW1U8/qIRi+CKJLS3xM=",
-      "dev": true
     },
     "har-schema": {
       "version": "1.0.5",
@@ -3367,8 +1013,8 @@
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
+        "ajv": "^4.9.1",
+        "har-schema": "^1.0.5"
       }
     },
     "has": {
@@ -3377,39 +1023,8 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "^1.0.2"
       }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "has-binary": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-      "dev": true
     },
     "has-flag": {
       "version": "1.0.0",
@@ -3429,7 +1044,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -3438,8 +1053,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -3448,10 +1063,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       },
       "dependencies": {
         "boom": {
@@ -3460,7 +1075,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "hoek": {
@@ -3471,54 +1086,15 @@
         }
       }
     },
-    "heap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-      "dev": true
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
-    },
-    "hpack.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "wbuf": "1.7.2"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "http-signature": {
@@ -3527,97 +1103,31 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
-    },
-    "idb-pull-blob-store": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/idb-pull-blob-store/-/idb-pull-blob-store-0.5.1.tgz",
-      "integrity": "sha1-nBP58Q6wWqOp8g71cVE8R1efddQ=",
-      "dev": true,
-      "requires": {
-        "dexie": "1.5.1",
-        "pull-defer": "0.2.2",
-        "pull-pushable": "2.1.1",
-        "pull-window": "2.1.4",
-        "pull-write": "1.1.4",
-        "typedarray-to-buffer": "3.1.2"
-      }
-    },
-    "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-      "dev": true
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-      "dev": true
-    },
-    "interface-connection": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.2.tgz",
-      "integrity": "sha1-5JSYg/bqeft+3QHuP0/KR6Kf0sQ=",
-      "dev": true,
-      "requires": {
-        "pull-defer": "0.2.2",
-        "timed-tape": "0.1.1"
-      }
-    },
-    "interface-pull-blob-store": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/interface-pull-blob-store/-/interface-pull-blob-store-0.6.0.tgz",
-      "integrity": "sha1-1Mo4v6Y00iwA9jHJANiTnzPIXrM=",
-      "dev": true,
-      "requires": {
-        "chai": "3.5.0",
-        "pull-stream": "3.6.0",
-        "pull-write": "1.1.4",
-        "run-series": "1.1.4"
-      }
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "ip": {
@@ -3626,263 +1136,14 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
-    "ip-address": {
-      "version": "5.8.8",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.8.8.tgz",
-      "integrity": "sha1-X9H490ZSSft9Kzwe7HtB0p0fG3Y=",
-      "dev": true,
-      "requires": {
-        "jsbn": "0.1.0",
-        "lodash.find": "4.6.0",
-        "lodash.max": "4.0.1",
-        "lodash.merge": "4.6.0",
-        "lodash.padstart": "4.6.1",
-        "lodash.repeat": "4.1.0",
-        "sprintf-js": "1.1.1",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "ipfs": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.18.0.tgz",
-      "integrity": "sha1-ihJUu70enLP3f8bGau6Fa1ZqkYk=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "bl": "1.2.1",
-        "boom": "4.3.1",
-        "debug": "2.6.8",
-        "fs-pull-blob-store": "0.3.0",
-        "glob": "7.1.2",
-        "hapi": "15.2.0",
-        "hapi-set-header": "1.0.2",
-        "idb-pull-blob-store": "0.5.1",
-        "ipfs-api": "11.2.0",
-        "ipfs-bitswap": "0.8.3",
-        "ipfs-block": "0.5.5",
-        "ipfs-block-service": "0.7.2",
-        "ipfs-multipart": "0.1.0",
-        "ipfs-repo": "0.11.3",
-        "ipfs-unixfs": "0.1.12",
-        "ipfs-unixfs-engine": "0.13.0",
-        "ipld-resolver": "0.2.0",
-        "isstream": "0.1.2",
-        "joi": "9.2.0",
-        "libp2p-ipfs": "0.15.0",
-        "libp2p-ipfs-browser": "0.16.0",
-        "lodash.flatmap": "4.5.0",
-        "lodash.get": "4.4.2",
-        "lodash.has": "4.5.2",
-        "lodash.set": "4.3.2",
-        "lodash.sortby": "4.7.0",
-        "lodash.values": "4.3.0",
-        "mafmt": "2.1.8",
-        "multiaddr": "2.3.0",
-        "multihashes": "0.2.2",
-        "path-exists": "3.0.0",
-        "peer-book": "0.3.2",
-        "peer-id": "0.8.8",
-        "peer-info": "0.8.5",
-        "promisify-es6": "1.0.3",
-        "pull-file": "1.0.0",
-        "pull-paramap": "1.2.2",
-        "pull-pushable": "2.1.1",
-        "pull-sort": "1.0.1",
-        "pull-stream": "3.6.0",
-        "pull-stream-to-stream": "1.3.4",
-        "pull-zip": "2.0.1",
-        "read-pkg-up": "2.0.0",
-        "readable-stream": "1.1.14",
-        "stream-to-pull-stream": "1.7.2",
-        "tar-stream": "1.5.4",
-        "temp": "0.8.3",
-        "through2": "2.0.3",
-        "update-notifier": "1.0.3",
-        "yargs": "6.6.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
-    "ipfs-api": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-11.2.0.tgz",
-      "integrity": "sha1-BlKdB+gCUIKzS9h6BfxxZ5if7Jg=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "bl": "1.2.1",
-        "bs58": "3.1.0",
-        "concat-stream": "1.6.0",
-        "detect-node": "2.0.3",
-        "flatmap": "0.0.3",
-        "glob": "7.1.2",
-        "ipfs-block": "0.5.5",
-        "ipld-dag-pb": "0.9.5",
-        "is-ipfs": "0.2.1",
-        "isstream": "0.1.2",
-        "lru-cache": "4.1.1",
-        "multiaddr": "2.3.0",
-        "multipart-stream": "2.0.1",
-        "ndjson": "1.5.0",
-        "once": "1.4.0",
-        "peer-id": "0.8.8",
-        "peer-info": "0.8.5",
-        "promisify-es6": "1.0.3",
-        "qs": "6.5.0",
-        "readable-stream": "1.1.14",
-        "stream-http": "2.7.2",
-        "streamifier": "0.1.1",
-        "tar-stream": "1.5.4"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
-    "ipfs-bitswap": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.8.3.tgz",
-      "integrity": "sha1-NUXZEBHTViqMz4ePx4fjt7tV5+M=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "cids": "0.3.6",
-        "debug": "2.6.8",
-        "heap": "0.2.6",
-        "ipfs-block": "0.5.5",
-        "lodash.debounce": "4.0.8",
-        "lodash.isequalwith": "4.4.0",
-        "lodash.isundefined": "3.0.1",
-        "multihashes": "0.3.3",
-        "protocol-buffers": "3.2.1",
-        "pull-defer": "0.2.2",
-        "pull-length-prefixed": "1.3.0",
-        "pull-paramap": "1.2.2",
-        "pull-pushable": "2.1.1",
-        "pull-stream": "3.6.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "base-x": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.2.tgz",
-          "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "3.0.2"
-          }
-        },
-        "cids": {
-          "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.3.6.tgz",
-          "integrity": "sha1-oKOiw4YQWpLs2cii8iOb6y9UTBU=",
-          "dev": true,
-          "requires": {
-            "multibase": "0.3.4",
-            "multicodec": "0.1.8",
-            "multihashes": "0.3.3"
-          }
-        },
-        "multihashes": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.3.3.tgz",
-          "integrity": "sha1-GNdNjCOTrzmq8KyPT9bYiNQ/Lyk=",
-          "dev": true,
-          "requires": {
-            "bs58": "4.0.1"
-          }
-        }
-      }
-    },
     "ipfs-block": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.5.5.tgz",
       "integrity": "sha1-lWpNGnWMJXT7U2JjRlXM+hwOvSQ=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "multihashing-async": "0.4.6"
+        "async": "^2.1.4",
+        "multihashing-async": "~0.4.2"
       },
       "dependencies": {
         "async": {
@@ -3891,133 +1152,18 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
     },
-    "ipfs-block-service": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.7.2.tgz",
-      "integrity": "sha1-GFks8UgZOR0Nx6H9s75iAdPG/uI=",
+    "ipfs-mini": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ipfs-mini/-/ipfs-mini-1.1.5.tgz",
+      "integrity": "sha512-BzsoCa3V/gxN2eEHnyqggOdreAwnvbddj4jUvp6Q7jXuzXx9q5XakXe8mG8qV0bn4bMKdH/7BUDbiWBCEMuYBg==",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "cids": "0.3.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "base-x": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.2.tgz",
-          "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "3.0.2"
-          }
-        },
-        "cids": {
-          "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.3.6.tgz",
-          "integrity": "sha1-oKOiw4YQWpLs2cii8iOb6y9UTBU=",
-          "dev": true,
-          "requires": {
-            "multibase": "0.3.4",
-            "multicodec": "0.1.8",
-            "multihashes": "0.3.3"
-          }
-        },
-        "multihashes": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.3.3.tgz",
-          "integrity": "sha1-GNdNjCOTrzmq8KyPT9bYiNQ/Lyk=",
-          "dev": true,
-          "requires": {
-            "bs58": "4.0.1"
-          }
-        }
-      }
-    },
-    "ipfs-multipart": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.1.0.tgz",
-      "integrity": "sha1-Wo7RP0LoLYvvfS4VHY6vXjow4+o=",
-      "dev": true,
-      "requires": {
-        "content": "3.0.5",
-        "dicer": "0.2.5"
-      }
-    },
-    "ipfs-repo": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.11.3.tgz",
-      "integrity": "sha1-65IZ+gkJVZz3LAzLZUniCKgIeko=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "base32.js": "0.1.0",
-        "ipfs-block": "0.5.5",
-        "lock": "0.1.4",
-        "multihashes": "0.3.3",
-        "pull-defer": "0.2.2",
-        "pull-stream": "3.6.0",
-        "pull-write": "1.1.4",
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "base-x": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.2.tgz",
-          "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "3.0.2"
-          }
-        },
-        "multihashes": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.3.3.tgz",
-          "integrity": "sha1-GNdNjCOTrzmq8KyPT9bYiNQ/Lyk=",
-          "dev": true,
-          "requires": {
-            "bs58": "4.0.1"
-          }
-        }
+        "xmlhttprequest": "^1.8.0"
       }
     },
     "ipfs-unixfs": {
@@ -4026,104 +1172,7 @@
       "integrity": "sha1-R/SFd2/Qhh1w4Xcf2rjk61zu3DM=",
       "dev": true,
       "requires": {
-        "protocol-buffers": "3.2.1"
-      }
-    },
-    "ipfs-unixfs-engine": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.13.0.tgz",
-      "integrity": "sha1-RgBDTkhyxViNryxOBOvPUZ1/P4o=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "cids": "0.2.0",
-        "ipfs-unixfs": "0.1.12",
-        "ipld-dag-pb": "0.8.0",
-        "ipld-resolver": "0.2.0",
-        "is-ipfs": "0.2.1",
-        "multihashes": "0.2.2",
-        "pull-block": "1.2.0",
-        "pull-paramap": "1.2.2",
-        "pull-pushable": "2.1.1",
-        "pull-stream": "3.6.0",
-        "pull-traverse": "1.0.3",
-        "pull-write": "1.1.4"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "cids": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.2.0.tgz",
-          "integrity": "sha1-Cnn2IcNOs/+cO+UF/aK4CXEIR/w=",
-          "dev": true,
-          "requires": {
-            "multibase": "0.2.0",
-            "multicodec": "0.1.0",
-            "multihashes": "0.2.2"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.8.0.tgz",
-          "integrity": "sha1-juNfLGgcasBGMA6Mgcwa2bhAxOI=",
-          "dev": true,
-          "requires": {
-            "async": "2.5.0",
-            "cids": "0.2.0",
-            "ipfs-block": "0.5.5",
-            "is-ipfs": "0.2.1",
-            "multihashes": "0.2.2",
-            "multihashing-async": "0.2.0",
-            "protocol-buffers": "3.2.1",
-            "pull-stream": "3.6.0",
-            "pull-traverse": "1.0.3",
-            "stable": "0.1.6"
-          }
-        },
-        "multibase": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.2.0.tgz",
-          "integrity": "sha1-jA+dX/M/hj3Eciyn0G3B3Z5fAG4=",
-          "dev": true,
-          "requires": {
-            "bs58": "3.1.0"
-          }
-        },
-        "multicodec": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.1.0.tgz",
-          "integrity": "sha1-AAZ/zAUX1XG+wcbzJdLJh7OnTMg=",
-          "dev": true,
-          "requires": {
-            "varint": "4.0.1"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.2.0.tgz",
-          "integrity": "sha1-jewZWiD+QCzKOOJyjWk2B9HFo3s=",
-          "dev": true,
-          "requires": {
-            "browserify-sha3": "0.0.2",
-            "multihashes": "0.2.2",
-            "nodeify": "1.0.1",
-            "sha3": "1.2.0"
-          }
-        },
-        "varint": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-4.0.1.tgz",
-          "integrity": "sha1-SQgpuULSSEY7KzUJeZXDv3NxmOk=",
-          "dev": true
-        }
+        "protocol-buffers": "^3.2.1"
       }
     },
     "ipfsd-ctl": {
@@ -4132,14 +1181,14 @@
       "integrity": "sha1-af4vCEtNkNif/1IYMfJ+r4fMWN0=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "^2.1.4",
         "go-ipfs-dep": "0.4.4",
-        "ipfs-api": "12.1.7",
-        "multiaddr": "2.3.0",
-        "once": "1.4.0",
-        "rimraf": "2.6.1",
-        "shutdown": "0.2.4",
-        "subcomandante": "1.0.5"
+        "ipfs-api": "^12.1.7",
+        "multiaddr": "^2.2.1",
+        "once": "^1.4.0",
+        "rimraf": "^2.5.4",
+        "shutdown": "^0.2.4",
+        "subcomandante": "^1.0.5"
       },
       "dependencies": {
         "async": {
@@ -4148,7 +1197,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "base-x": {
@@ -4157,7 +1206,7 @@
           "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "bs58": {
@@ -4166,7 +1215,7 @@
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
-            "base-x": "3.0.2"
+            "base-x": "^3.0.2"
           }
         },
         "ipfs-api": {
@@ -4175,34 +1224,34 @@
           "integrity": "sha1-HVjBJoOqEvdSnNUrnf8Yu2kVu6o=",
           "dev": true,
           "requires": {
-            "async": "2.5.0",
-            "bs58": "4.0.1",
-            "cids": "0.4.2",
-            "concat-stream": "1.6.0",
-            "detect-node": "2.0.3",
+            "async": "^2.1.4",
+            "bs58": "^4.0.0",
+            "cids": "~0.4.1",
+            "concat-stream": "^1.6.0",
+            "detect-node": "^2.0.3",
             "flatmap": "0.0.3",
-            "glob": "7.1.2",
+            "glob": "^7.1.1",
             "glob-escape": "0.0.2",
-            "ipfs-block": "0.5.5",
-            "ipfs-unixfs": "0.1.12",
-            "ipld-dag-pb": "0.9.5",
-            "is-ipfs": "0.3.0",
-            "isstream": "0.1.2",
-            "lru-cache": "4.1.1",
-            "multiaddr": "2.3.0",
-            "multihashes": "0.3.3",
-            "multipart-stream": "2.0.1",
-            "ndjson": "1.5.0",
-            "once": "1.4.0",
-            "peer-id": "0.8.8",
-            "peer-info": "0.8.5",
-            "promisify-es6": "1.0.3",
-            "pump": "1.0.2",
-            "qs": "6.5.0",
+            "ipfs-block": "~0.5.5",
+            "ipfs-unixfs": "~0.1.10",
+            "ipld-dag-pb": "~0.9.5",
+            "is-ipfs": "~0.3.0",
+            "isstream": "^0.1.2",
+            "lru-cache": "^4.0.2",
+            "multiaddr": "^2.2.1",
+            "multihashes": "~0.3.3",
+            "multipart-stream": "^2.0.1",
+            "ndjson": "^1.5.0",
+            "once": "^1.4.0",
+            "peer-id": "~0.8.2",
+            "peer-info": "~0.8.3",
+            "promisify-es6": "^1.0.2",
+            "pump": "^1.0.2",
+            "qs": "^6.3.0",
             "readable-stream": "1.1.14",
-            "stream-http": "2.7.2",
-            "streamifier": "0.1.1",
-            "tar-stream": "1.5.4"
+            "stream-http": "^2.6.3",
+            "streamifier": "^0.1.1",
+            "tar-stream": "^1.5.2"
           }
         },
         "is-ipfs": {
@@ -4211,8 +1260,8 @@
           "integrity": "sha1-yZNfIrGd9QqX57Jl+VreTCka05U=",
           "dev": true,
           "requires": {
-            "bs58": "4.0.1",
-            "multihashes": "0.3.3"
+            "bs58": "^4.0.0",
+            "multihashes": "^0.3.2"
           }
         },
         "isarray": {
@@ -4227,7 +1276,7 @@
           "integrity": "sha1-GNdNjCOTrzmq8KyPT9bYiNQ/Lyk=",
           "dev": true,
           "requires": {
-            "bs58": "4.0.1"
+            "bs58": "^4.0.0"
           }
         },
         "readable-stream": {
@@ -4236,10 +1285,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "rimraf": {
@@ -4248,7 +1297,7 @@
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "string_decoder": {
@@ -4256,60 +1305,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
-        }
-      }
-    },
-    "ipld-dag-cbor": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.8.6.tgz",
-      "integrity": "sha1-oKk/T1TbayYgDtsX3VC+H9u71dY=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "borc": "2.0.2",
-        "bs58": "4.0.1",
-        "cids": "0.4.2",
-        "is-circular": "1.0.1",
-        "multihashes": "0.3.3",
-        "multihashing-async": "0.4.6",
-        "traverse": "0.6.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "base-x": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.2.tgz",
-          "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "3.0.2"
-          }
-        },
-        "multihashes": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.3.3.tgz",
-          "integrity": "sha1-GNdNjCOTrzmq8KyPT9bYiNQ/Lyk=",
-          "dev": true,
-          "requires": {
-            "bs58": "4.0.1"
-          }
         }
       }
     },
@@ -4319,17 +1314,17 @@
       "integrity": "sha1-6MfcYaTdg6hlhzVVkmTuT+3YtjU=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "^2.1.4",
         "buffer-loader": "0.0.1",
-        "cids": "0.4.2",
-        "ipfs-block": "0.5.5",
-        "is-ipfs": "0.3.0",
-        "multihashes": "0.3.3",
-        "multihashing-async": "0.4.6",
-        "protocol-buffers": "3.2.1",
-        "pull-stream": "3.6.0",
-        "pull-traverse": "1.0.3",
-        "stable": "0.1.6"
+        "cids": "~0.4.1",
+        "ipfs-block": "~0.5.4",
+        "is-ipfs": "~0.3.0",
+        "multihashes": "~0.3.3",
+        "multihashing-async": "~0.4.2",
+        "protocol-buffers": "^3.2.1",
+        "pull-stream": "^3.5.0",
+        "pull-traverse": "^1.0.3",
+        "stable": "^0.1.5"
       },
       "dependencies": {
         "async": {
@@ -4338,7 +1333,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "base-x": {
@@ -4347,7 +1342,7 @@
           "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "bs58": {
@@ -4356,7 +1351,7 @@
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
-            "base-x": "3.0.2"
+            "base-x": "^3.0.2"
           }
         },
         "is-ipfs": {
@@ -4365,8 +1360,8 @@
           "integrity": "sha1-yZNfIrGd9QqX57Jl+VreTCka05U=",
           "dev": true,
           "requires": {
-            "bs58": "4.0.1",
-            "multihashes": "0.3.3"
+            "bs58": "^4.0.0",
+            "multihashes": "^0.3.2"
           }
         },
         "multihashes": {
@@ -4375,154 +1370,10 @@
           "integrity": "sha1-GNdNjCOTrzmq8KyPT9bYiNQ/Lyk=",
           "dev": true,
           "requires": {
-            "bs58": "4.0.1"
+            "bs58": "^4.0.0"
           }
         }
       }
-    },
-    "ipld-resolver": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ipld-resolver/-/ipld-resolver-0.2.0.tgz",
-      "integrity": "sha1-0njtcqQ6mKlt9hGeVD5RLW4l0aI=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "cids": "0.2.0",
-        "interface-pull-blob-store": "0.6.0",
-        "ipfs-block": "0.5.5",
-        "ipfs-block-service": "0.6.0",
-        "ipfs-repo": "0.11.3",
-        "ipld-dag-cbor": "0.8.6",
-        "ipld-dag-pb": "0.8.0",
-        "is-ipfs": "0.2.1",
-        "lodash.flatten": "4.4.0",
-        "lodash.includes": "4.3.0",
-        "multihashes": "0.2.2",
-        "pull-stream": "3.6.0",
-        "pull-traverse": "1.0.3"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "cids": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.2.0.tgz",
-          "integrity": "sha1-Cnn2IcNOs/+cO+UF/aK4CXEIR/w=",
-          "dev": true,
-          "requires": {
-            "multibase": "0.2.0",
-            "multicodec": "0.1.0",
-            "multihashes": "0.2.2"
-          }
-        },
-        "ipfs-block-service": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.6.0.tgz",
-          "integrity": "sha1-5TekYk6wBlh/bmGga8F1Dq5Mt0o=",
-          "dev": true,
-          "requires": {
-            "cids": "0.2.0",
-            "pull-stream": "3.6.0",
-            "run-parallel-limit": "1.0.3"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.8.0.tgz",
-          "integrity": "sha1-juNfLGgcasBGMA6Mgcwa2bhAxOI=",
-          "dev": true,
-          "requires": {
-            "async": "2.5.0",
-            "cids": "0.2.0",
-            "ipfs-block": "0.5.5",
-            "is-ipfs": "0.2.1",
-            "multihashes": "0.2.2",
-            "multihashing-async": "0.2.0",
-            "protocol-buffers": "3.2.1",
-            "pull-stream": "3.6.0",
-            "pull-traverse": "1.0.3",
-            "stable": "0.1.6"
-          }
-        },
-        "multibase": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.2.0.tgz",
-          "integrity": "sha1-jA+dX/M/hj3Eciyn0G3B3Z5fAG4=",
-          "dev": true,
-          "requires": {
-            "bs58": "3.1.0"
-          }
-        },
-        "multicodec": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.1.0.tgz",
-          "integrity": "sha1-AAZ/zAUX1XG+wcbzJdLJh7OnTMg=",
-          "dev": true,
-          "requires": {
-            "varint": "4.0.1"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.2.0.tgz",
-          "integrity": "sha1-jewZWiD+QCzKOOJyjWk2B9HFo3s=",
-          "dev": true,
-          "requires": {
-            "browserify-sha3": "0.0.2",
-            "multihashes": "0.2.2",
-            "nodeify": "1.0.1",
-            "sha3": "1.2.0"
-          }
-        },
-        "varint": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-4.0.1.tgz",
-          "integrity": "sha1-SQgpuULSSEY7KzUJeZXDv3NxmOk=",
-          "dev": true
-        }
-      }
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "optional": true,
-      "requires": {
-        "binary-extensions": "1.9.0"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
-    },
-    "is-circular": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.1.tgz",
-      "integrity": "sha1-ZbBHaoWI5Ua4CHwdZtTAjYKjFnk=",
-      "dev": true
     },
     "is-deflate": {
       "version": "1.0.0",
@@ -4530,55 +1381,13 @@
       "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ=",
       "dev": true
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "optional": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "optional": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "optional": true
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "requires": {
-        "is-extglob": "1.0.0"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-gzip": {
@@ -4592,48 +1401,6 @@
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
-    "is-ipfs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.2.1.tgz",
-      "integrity": "sha1-EDV9P93Hze1LbqbMHab+fY2EtDg=",
-      "dev": true,
-      "requires": {
-        "bs58": "3.1.0",
-        "multihashes": "0.2.2"
-      }
-    },
-    "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true
-    },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "optional": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "optional": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-    },
     "is-promise": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
@@ -4644,18 +1411,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
       "dev": true
     },
     "is-running": {
@@ -4676,31 +1431,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isemail": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "optional": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -4708,45 +1443,17 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "items": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
-      "dev": true
-    },
-    "joi": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
-      "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.0",
-        "isemail": "2.2.1",
-        "items": "2.1.1",
-        "moment": "2.18.1",
-        "topo": "2.0.2"
-      }
-    },
     "js-sha3": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
       "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
     },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-    },
     "jsbn": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
       "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-      "dev": true
-    },
-    "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "dev": true,
+      "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -4755,9 +1462,9 @@
       "dev": true
     },
     "json-schema-to-markdown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/json-schema-to-markdown/-/json-schema-to-markdown-1.0.3.tgz",
-      "integrity": "sha1-RBHKIisrZ2DmFmY/C7K9drsm67g=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-markdown/-/json-schema-to-markdown-1.1.1.tgz",
+      "integrity": "sha512-AWah/3VoorCoBBtnzZnGUjUey9WbMx1HjENyFXh/hYgnohL5XWZ6JKdaNMRn/ZExyPIsEXWqukVw2kacoGqAIQ==",
       "dev": true
     },
     "json-stable-stringify": {
@@ -4766,7 +1473,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -4775,32 +1482,18 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "dev": true,
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -4810,9 +1503,9 @@
       "dev": true
     },
     "jsonschema": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.1.1.tgz",
-      "integrity": "sha1-PO3o4+QR03eHLu+8n98mODy8Ptk=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.6.tgz",
+      "integrity": "sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA==",
       "dev": true
     },
     "jsprim": {
@@ -4841,50 +1534,13 @@
       "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs=",
       "dev": true
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.5"
-      }
-    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
-    },
-    "latest-version": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
-      "dev": true,
-      "requires": {
-        "package-json": "2.4.0"
-      }
-    },
-    "lazy-req": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
-      "dev": true
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
-    },
-    "left-pad": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
-      "integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo="
     },
     "libp2p-crypto": {
       "version": "0.8.8",
@@ -4892,20 +1548,20 @@
       "integrity": "sha1-3IpJy87bUjnel3YZ8tGN+fwRDzk=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.1",
-        "async": "2.5.0",
-        "browserify-aes": "1.0.6",
-        "keypair": "1.0.1",
-        "libp2p-crypto-secp256k1": "0.1.4",
-        "multihashing-async": "0.4.6",
-        "node-webcrypto-ossl": "1.0.30",
-        "nodeify": "1.0.1",
-        "pem-jwk": "1.5.1",
-        "protocol-buffers": "3.2.1",
-        "rsa-pem-to-jwk": "1.1.3",
-        "safe-buffer": "5.1.1",
-        "tweetnacl": "1.0.0",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#effe03d3401ccbfb4837191bc393bb347e0c0f0a"
+        "asn1.js": "^4.9.1",
+        "async": "^2.1.5",
+        "browserify-aes": "^1.0.6",
+        "keypair": "^1.0.1",
+        "libp2p-crypto-secp256k1": "^0.1.4",
+        "multihashing-async": "~0.4.4",
+        "node-webcrypto-ossl": "^1.0.21",
+        "nodeify": "^1.0.1",
+        "pem-jwk": "^1.5.1",
+        "protocol-buffers": "^3.2.1",
+        "rsa-pem-to-jwk": "^1.1.3",
+        "safe-buffer": "^5.0.1",
+        "tweetnacl": "^1.0.0-rc.1",
+        "webcrypto-shim": "webcrypto-shim@github:dignifiedquire/webcrypto-shim#effe03d3401ccbfb4837191bc393bb347e0c0f0a"
       },
       "dependencies": {
         "async": {
@@ -4914,7 +1570,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -4925,12 +1581,12 @@
       "integrity": "sha1-IRN4/jqFnYmtEgOqng111obIW98=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "libp2p-crypto": "0.8.8",
-        "multihashing-async": "0.4.6",
-        "nodeify": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "secp256k1": "3.3.0"
+        "async": "^2.1.4",
+        "libp2p-crypto": "~0.8.4",
+        "multihashing-async": "~0.4.2",
+        "nodeify": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "secp256k1": "^3.2.5"
       },
       "dependencies": {
         "async": {
@@ -4939,229 +1595,10 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
-    },
-    "libp2p-identify": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.3.3.tgz",
-      "integrity": "sha1-cObE0yK570dadc5XtLtomK23Xyk=",
-      "dev": true,
-      "requires": {
-        "multiaddr": "2.3.0",
-        "peer-id": "0.8.8",
-        "peer-info": "0.8.5",
-        "protocol-buffers": "3.2.1",
-        "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.0"
-      }
-    },
-    "libp2p-ipfs": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/libp2p-ipfs/-/libp2p-ipfs-0.15.0.tgz",
-      "integrity": "sha1-4suhQYWwTrz3lIhvn0iwTEjjkLs=",
-      "dev": true,
-      "requires": {
-        "libp2p-secio": "0.6.8",
-        "libp2p-spdy": "0.10.6",
-        "libp2p-swarm": "0.26.19",
-        "libp2p-tcp": "0.9.4",
-        "libp2p-websockets": "0.9.6",
-        "mafmt": "2.1.8",
-        "multiaddr": "2.3.0",
-        "peer-book": "0.3.2",
-        "peer-id": "0.8.8",
-        "peer-info": "0.8.5"
-      }
-    },
-    "libp2p-ipfs-browser": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/libp2p-ipfs-browser/-/libp2p-ipfs-browser-0.16.0.tgz",
-      "integrity": "sha1-/LLAsNvKChxhdakhjSj4hhk5wPk=",
-      "dev": true,
-      "requires": {
-        "libp2p-secio": "0.6.8",
-        "libp2p-spdy": "0.10.6",
-        "libp2p-swarm": "0.26.19",
-        "libp2p-webrtc-star": "0.5.0",
-        "libp2p-websockets": "0.9.6",
-        "mafmt": "2.1.8",
-        "multiaddr": "2.3.0",
-        "peer-book": "0.3.2",
-        "peer-id": "0.8.8",
-        "peer-info": "0.8.5"
-      }
-    },
-    "libp2p-secio": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.6.8.tgz",
-      "integrity": "sha1-KaRKciWg9hSRmfzAuwl3KskV7gM=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "debug": "2.6.8",
-        "interface-connection": "0.3.2",
-        "libp2p-crypto": "0.8.8",
-        "multihashing-async": "0.4.6",
-        "peer-id": "0.8.8",
-        "protocol-buffers": "3.2.1",
-        "pull-defer": "0.2.2",
-        "pull-handshake": "1.1.4",
-        "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        }
-      }
-    },
-    "libp2p-spdy": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/libp2p-spdy/-/libp2p-spdy-0.10.6.tgz",
-      "integrity": "sha1-p8GCjR3mEVjixDL2wtHbyOJTgDU=",
-      "dev": true,
-      "requires": {
-        "browserify-zlib-next": "1.0.1",
-        "interface-connection": "0.3.2",
-        "lodash.noop": "3.0.1",
-        "pull-stream-to-stream": "1.3.4",
-        "spdy-transport": "2.0.20",
-        "stream-to-pull-stream": "1.7.2"
-      }
-    },
-    "libp2p-swarm": {
-      "version": "0.26.19",
-      "resolved": "https://registry.npmjs.org/libp2p-swarm/-/libp2p-swarm-0.26.19.tgz",
-      "integrity": "sha1-MF+rEItuuu7aoZCxlhossKIk+X4=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "browserify-zlib-next": "1.0.1",
-        "debug": "2.6.8",
-        "interface-connection": "0.3.2",
-        "ip-address": "5.8.8",
-        "libp2p-identify": "0.3.3",
-        "lodash.includes": "4.3.0",
-        "multiaddr": "2.3.0",
-        "multistream-select": "0.13.5",
-        "once": "1.4.0",
-        "peer-id": "0.8.8",
-        "peer-info": "0.8.5",
-        "protocol-buffers": "3.2.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        }
-      }
-    },
-    "libp2p-tcp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.9.4.tgz",
-      "integrity": "sha1-nA3EF30zQeBPnxQL1VpLjcaHctg=",
-      "dev": true,
-      "requires": {
-        "interface-connection": "0.3.2",
-        "ip-address": "5.8.8",
-        "lodash.includes": "4.3.0",
-        "lodash.isfunction": "3.0.8",
-        "mafmt": "2.1.8",
-        "multiaddr": "2.3.0",
-        "stream-to-pull-stream": "1.7.2"
-      }
-    },
-    "libp2p-webrtc-star": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.5.0.tgz",
-      "integrity": "sha1-PNHlVJUQDkcy9eP+eKruKNjQcSo=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "debug": "2.6.8",
-        "hapi": "15.2.0",
-        "interface-connection": "0.3.2",
-        "mafmt": "2.1.8",
-        "minimist": "1.2.0",
-        "peer-id": "0.8.8",
-        "peer-info": "0.8.5",
-        "pull-stream": "3.6.0",
-        "simple-peer": "6.4.4",
-        "socket.io": "1.7.4",
-        "socket.io-client": "1.7.4",
-        "stream-to-pull-stream": "1.7.2"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "libp2p-websockets": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.9.6.tgz",
-      "integrity": "sha1-Ht8vVDqUvhiFynpWWQ0WytVngGs=",
-      "dev": true,
-      "requires": {
-        "interface-connection": "0.3.2",
-        "lodash.includes": "4.3.0",
-        "mafmt": "2.1.8",
-        "pull-ws": "3.2.9"
-      }
-    },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      }
-    },
-    "lock": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
-      "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0=",
-      "dev": true
     },
     "lodash": {
       "version": "4.17.4",
@@ -5174,8 +1611,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -5208,57 +1645,15 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
     },
     "lodash.filter": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
-      "dev": true
-    },
-    "lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
-      "dev": true
-    },
-    "lodash.flatmap": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
-      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=",
-      "dev": true
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
-      "dev": true
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "dev": true
     },
     "lodash.isarguments": {
@@ -5273,33 +1668,15 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
-    "lodash.isequalwith": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
-      "integrity": "sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA=",
-      "dev": true
-    },
-    "lodash.isfunction": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
-      "integrity": "sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs=",
-      "dev": true
-    },
-    "lodash.isundefined": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
-      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g=",
-      "dev": true
-    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.map": {
@@ -5308,84 +1685,10 @@
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
       "dev": true
     },
-    "lodash.max": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
-      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o=",
-      "dev": true
-    },
-    "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
-      "dev": true
-    },
-    "lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw=",
-      "dev": true
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true
-    },
-    "lodash.range": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
-      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0=",
-      "dev": true
-    },
-    "lodash.repeat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
-      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ=",
-      "dev": true
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-      "dev": true
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
-    },
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
-      "dev": true
-    },
-    "lodash.values": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
-      "dev": true
-    },
-    "looper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-      "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew=",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
     },
     "lru-cache": {
@@ -5394,17 +1697,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
-    "mafmt": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-2.1.8.tgz",
-      "integrity": "sha1-2Lf3Y75W22KgNDvFxH04qyy+9F4=",
-      "dev": true,
-      "requires": {
-        "multiaddr": "2.3.0"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "match-stream": {
@@ -5413,8 +1707,8 @@
       "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
       "dev": true,
       "requires": {
-        "buffers": "0.1.1",
-        "readable-stream": "1.0.34"
+        "buffers": "~0.1.1",
+        "readable-stream": "~1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -5429,10 +1723,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5441,27 +1735,6 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
-      }
-    },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "optional": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
       }
     },
     "mime-db": {
@@ -5476,7 +1749,7 @@
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
       "dev": true,
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "~1.29.0"
       }
     },
     "minimalistic-assert": {
@@ -5495,19 +1768,22 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -5537,7 +1813,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "debug": {
@@ -5575,21 +1851,16 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
     },
-    "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "multiaddr": {
       "version": "2.3.0",
@@ -5597,12 +1868,12 @@
       "integrity": "sha1-VmNIJPSLy9hAX9VDTDGyd0JMYvw=",
       "dev": true,
       "requires": {
-        "bs58": "4.0.1",
-        "ip": "1.1.5",
-        "lodash.filter": "4.6.0",
-        "lodash.map": "4.6.0",
-        "varint": "5.0.0",
-        "xtend": "4.0.1"
+        "bs58": "^4.0.0",
+        "ip": "^1.1.5",
+        "lodash.filter": "^4.6.0",
+        "lodash.map": "^4.6.0",
+        "varint": "^5.0.0",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "base-x": {
@@ -5611,7 +1882,7 @@
           "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "bs58": {
@@ -5620,7 +1891,7 @@
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
-            "base-x": "3.0.2"
+            "base-x": "^3.0.2"
           }
         }
       }
@@ -5648,16 +1919,7 @@
       "integrity": "sha1-Lt4AphxPltBzW4ZxIa66BF0N6/I=",
       "dev": true,
       "requires": {
-        "varint": "5.0.0"
-      }
-    },
-    "multihashes": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.2.2.tgz",
-      "integrity": "sha1-jM8uO6PQQeEUZyjeDYpNqeixglE=",
-      "dev": true,
-      "requires": {
-        "bs58": "3.1.0"
+        "varint": "^5.0.0"
       }
     },
     "multihashing-async": {
@@ -5666,12 +1928,12 @@
       "integrity": "sha1-sByNB0XMrAha/XqaXoGC9zUF1/c=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "blakejs": "1.1.0",
-        "js-sha3": "0.6.1",
-        "multihashes": "0.4.5",
-        "murmurhash3js": "3.0.1",
-        "nodeify": "1.0.1"
+        "async": "^2.5.0",
+        "blakejs": "^1.1.0",
+        "js-sha3": "^0.6.1",
+        "multihashes": "~0.4.5",
+        "murmurhash3js": "^3.0.1",
+        "nodeify": "^1.0.1"
       },
       "dependencies": {
         "async": {
@@ -5680,7 +1942,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "base-x": {
@@ -5689,7 +1951,7 @@
           "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "bs58": {
@@ -5698,7 +1960,7 @@
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
-            "base-x": "3.0.2"
+            "base-x": "^3.0.2"
           }
         },
         "js-sha3": {
@@ -5713,8 +1975,8 @@
           "integrity": "sha1-mwU8Uf3HTXce3eIOG8kdS77D+mk=",
           "dev": true,
           "requires": {
-            "bs58": "4.0.1",
-            "varint": "5.0.0"
+            "bs58": "^4.0.0",
+            "varint": "^5.0.0"
           }
         }
       }
@@ -5725,39 +1987,9 @@
       "integrity": "sha1-GVyctLLEHnjHKh6POMfQ66HNC6A=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "is-stream": "1.1.0",
-        "sandwich-stream": "1.0.0"
-      }
-    },
-    "multistream-select": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.13.5.tgz",
-      "integrity": "sha1-/jNnYgLmRhkFSu60UzaogcycVOk=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "debug": "2.6.8",
-        "interface-connection": "0.3.2",
-        "lodash.isfunction": "3.0.8",
-        "lodash.range": "3.2.0",
-        "once": "1.4.0",
-        "pull-handshake": "1.1.4",
-        "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.0",
-        "semver": "5.4.1",
-        "varint": "5.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        }
+        "inherits": "^2.0.1",
+        "is-stream": "^1.0.1",
+        "sandwich-stream": "^1.0.0"
       }
     },
     "murmurhash3js": {
@@ -5769,7 +2001,8 @@
     "nan": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "dev": true
     },
     "natives": {
       "version": "1.1.0",
@@ -5783,10 +2016,10 @@
       "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
       "dev": true,
       "requires": {
-        "json-stringify-safe": "5.0.1",
-        "minimist": "1.2.0",
-        "split2": "2.1.1",
-        "through2": "2.0.3"
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -5796,12 +2029,6 @@
           "dev": true
         }
       }
-    },
-    "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
     },
     "node-abi": {
       "version": "2.1.0",
@@ -5815,14 +2042,8 @@
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.2"
       }
-    },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "dev": true
     },
     "node-webcrypto-ossl": {
       "version": "1.0.30",
@@ -5831,11 +2052,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "@types/node": "6.0.85",
-        "mkdirp": "0.5.1",
-        "nan": "2.6.2",
-        "tslib": "1.7.1",
-        "webcrypto-core": "0.1.16"
+        "@types/node": "^6",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.5.1",
+        "tslib": "^1.7.1",
+        "webcrypto-core": "^0.1.16"
       }
     },
     "nodegit-promise": {
@@ -5844,7 +2065,7 @@
       "integrity": "sha1-VyKxhPLfcycWEGSnkdLoQskWezQ=",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "nodeify": {
@@ -5853,8 +2074,8 @@
       "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
       "dev": true,
       "requires": {
-        "is-promise": "1.0.1",
-        "promise": "1.3.0"
+        "is-promise": "~1.0.0",
+        "promise": "~1.3.0"
       }
     },
     "noop-logger": {
@@ -5863,42 +2084,23 @@
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
       "dev": true
     },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
-      }
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
-        "remove-trailing-separator": "1.0.2"
-      }
-    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "number-to-bn": {
       "version": "1.7.0",
@@ -5918,12 +2120,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-inspect": {
@@ -5938,28 +2135,13 @@
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "optional": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
-    },
-    "obuf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
-      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -5968,53 +2150,20 @@
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "dev": true,
       "requires": {
-        "wordwrap": "0.0.3"
+        "wordwrap": "~0.0.2"
       }
-    },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
-      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "1.0.0"
-      }
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "over": {
       "version": "0.0.5",
@@ -6022,97 +2171,11 @@
       "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg=",
       "dev": true
     },
-    "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "1.1.0"
-      }
-    },
-    "package-json": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
-      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
-      "dev": true,
-      "requires": {
-        "got": "5.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
-      }
-    },
-    "pako": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz",
-      "integrity": "sha1-0iBd/ludqK95fnwWPbTR+E5GALw=",
-      "dev": true
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "optional": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "1.3.1"
-      }
-    },
-    "parsejson": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
-      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
-    },
-    "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
-    },
-    "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -6120,52 +2183,14 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
-      "requires": {
-        "pify": "2.3.0"
-      }
-    },
     "peek-stream": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz",
       "integrity": "sha1-l+t2NlvP2MieKH9VyLadTD6bzFI=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.0",
-        "through2": "2.0.3"
-      }
-    },
-    "peer-book": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.3.2.tgz",
-      "integrity": "sha1-Kl9CrLGbvDFwoTrv+0szEDiP6vQ=",
-      "dev": true,
-      "requires": {
-        "bs58": "4.0.1"
-      },
-      "dependencies": {
-        "base-x": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.2.tgz",
-          "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "3.0.2"
-          }
-        }
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
       }
     },
     "peer-id": {
@@ -6174,10 +2199,10 @@
       "integrity": "sha1-TT2lXp7e5jNKiG/OJ0CCi7XytwI=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "libp2p-crypto": "0.8.8",
-        "lodash": "4.17.4",
-        "multihashes": "0.4.5"
+        "async": "^2.5.0",
+        "libp2p-crypto": "~0.8.8",
+        "lodash": "^4.17.4",
+        "multihashes": "~0.4.5"
       },
       "dependencies": {
         "async": {
@@ -6186,7 +2211,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "base-x": {
@@ -6195,7 +2220,7 @@
           "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "bs58": {
@@ -6204,7 +2229,7 @@
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
-            "base-x": "3.0.2"
+            "base-x": "^3.0.2"
           }
         },
         "multihashes": {
@@ -6213,8 +2238,8 @@
           "integrity": "sha1-mwU8Uf3HTXce3eIOG8kdS77D+mk=",
           "dev": true,
           "requires": {
-            "bs58": "4.0.1",
-            "varint": "5.0.0"
+            "bs58": "^4.0.0",
+            "varint": "^5.0.0"
           }
         }
       }
@@ -6225,9 +2250,9 @@
       "integrity": "sha1-uPvuY3ZAXATItkRhDNBiMcQmKh4=",
       "dev": true,
       "requires": {
-        "lodash.uniqby": "4.7.0",
-        "multiaddr": "2.3.0",
-        "peer-id": "0.8.8"
+        "lodash.uniqby": "^4.7.0",
+        "multiaddr": "^2.2.3",
+        "peer-id": "^0.8.5"
       }
     },
     "pem-jwk": {
@@ -6245,9 +2270,9 @@
           "integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
           "dev": true,
           "requires": {
-            "bn.js": "1.3.0",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "bn.js": {
@@ -6265,46 +2290,25 @@
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
     "prebuild-install": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.1.tgz",
       "integrity": "sha512-y/sgNJ49vjXQ3qYdSI/jTRZq6D7g5Q2euK6x0/L8dvwK1EGvNLidtg2t4PZzTgkR6LahkzpYVshOmHKYtp0AlQ==",
       "dev": true,
       "requires": {
-        "expand-template": "1.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.1.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "1.0.2",
-        "rc": "1.2.1",
-        "simple-get": "1.4.3",
-        "tar-fs": "1.15.3",
-        "tunnel-agent": "0.6.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.0.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^1.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^1.4.2",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
         "xtend": "4.0.1"
       },
       "dependencies": {
@@ -6316,27 +2320,11 @@
         }
       }
     },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "optional": true
-    },
-    "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
-    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "promise": {
       "version": "1.3.0",
@@ -6344,7 +2332,7 @@
       "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
       "dev": true,
       "requires": {
-        "is-promise": "1.0.1"
+        "is-promise": "~1"
       }
     },
     "promisify-es6": {
@@ -6359,8 +2347,8 @@
       "integrity": "sha1-MoA4dOxBF4TkeGwzmQKoeheaRpw=",
       "dev": true,
       "requires": {
-        "nodegit-promise": "4.0.0",
-        "object-assign": "4.1.1"
+        "nodegit-promise": "~4.0.0",
+        "object-assign": "^4.0.1"
       }
     },
     "protocol-buffers": {
@@ -6369,12 +2357,12 @@
       "integrity": "sha1-NyWOF+JKCC8G67F3MekoUdHHaIk=",
       "dev": true,
       "requires": {
-        "brfs": "1.4.3",
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "protocol-buffers-schema": "3.3.1",
-        "signed-varint": "2.0.1",
-        "varint": "5.0.0"
+        "brfs": "^1.4.0",
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.2.0",
+        "protocol-buffers-schema": "^3.1.1",
+        "signed-varint": "^2.0.0",
+        "varint": "^5.0.0"
       }
     },
     "protocol-buffers-schema": {
@@ -6389,195 +2377,16 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "pull-block": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pull-block/-/pull-block-1.2.0.tgz",
-      "integrity": "sha1-45R/CoNCboR+zs7LC5ujCLAZs+E=",
-      "dev": true,
-      "requires": {
-        "pull-through": "1.0.18",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "pull-cat": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-      "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs=",
-      "dev": true
-    },
-    "pull-defer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
-      "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM=",
-      "dev": true
-    },
-    "pull-file": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.0.0.tgz",
-      "integrity": "sha1-WgywNteO4Q4+C0KT389u/6EDYxg=",
-      "dev": true,
-      "requires": {
-        "pull-utf8-decoder": "1.0.2"
-      }
-    },
-    "pull-handshake": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
-      "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
-      "dev": true,
-      "requires": {
-        "pull-cat": "1.1.11",
-        "pull-pair": "1.1.0",
-        "pull-pushable": "2.1.1",
-        "pull-reader": "1.2.9"
-      }
-    },
-    "pull-length-prefixed": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.0.tgz",
-      "integrity": "sha512-FkxMYPNUSFjEDEXuS6MAaKwagQAN0sonifeC+NeutQmgXy+WBdPOtPzDT1dyT69Io1wzraZ+GzXAbBGnFcjdFQ==",
-      "dev": true,
-      "requires": {
-        "pull-pushable": "2.1.1",
-        "pull-reader": "1.2.9",
-        "safe-buffer": "5.1.1",
-        "varint": "5.0.0"
-      }
-    },
-    "pull-pair": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
-      "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120=",
-      "dev": true
-    },
-    "pull-paramap": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
-      "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
-      "dev": true,
-      "requires": {
-        "looper": "4.0.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU=",
-          "dev": true
-        }
-      }
-    },
-    "pull-pushable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.1.tgz",
-      "integrity": "sha1-hmZqu+P1QC8ffq0D7v1pt4Xspbg=",
-      "dev": true
-    },
-    "pull-reader": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
-      "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A=",
-      "dev": true
-    },
-    "pull-sort": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.1.tgz",
-      "integrity": "sha1-qKsMcMhvRTQ8mszJOfxCdprT3G0=",
-      "dev": true,
-      "requires": {
-        "pull-defer": "0.2.2",
-        "pull-stream": "3.6.0"
-      }
-    },
     "pull-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.0.tgz",
       "integrity": "sha1-WdAzpoFdTjCX1Hw9KxiTqeWKI1E=",
       "dev": true
     },
-    "pull-stream-to-stream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz",
-      "integrity": "sha1-P4HYIWvRjSv9GhmBkEcRgOJzg5k=",
-      "dev": true
-    },
-    "pull-through": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
-      "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
-      "dev": true,
-      "requires": {
-        "looper": "3.0.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k=",
-          "dev": true
-        }
-      }
-    },
     "pull-traverse": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
       "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg=",
-      "dev": true
-    },
-    "pull-utf8-decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
-      "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc=",
-      "dev": true
-    },
-    "pull-window": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-      "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
-      "dev": true,
-      "requires": {
-        "looper": "2.0.0"
-      }
-    },
-    "pull-write": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
-      "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
-      "dev": true,
-      "requires": {
-        "looper": "4.0.0",
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU=",
-          "dev": true
-        }
-      }
-    },
-    "pull-write-file": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/pull-write-file/-/pull-write-file-0.2.4.tgz",
-      "integrity": "sha1-Q3NErrIYn2XmeO0a838PdgpUU+8=",
-      "dev": true
-    },
-    "pull-ws": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.2.9.tgz",
-      "integrity": "sha1-ipBQKkHZBY/LMJatSCOg8YnWE7o=",
-      "dev": true,
-      "requires": {
-        "relative-url": "1.0.2",
-        "ws": "1.1.4"
-      }
-    },
-    "pull-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pull-zip/-/pull-zip-2.0.1.tgz",
-      "integrity": "sha1-4GQc6v+WSvJ1ltqsBwDnmzgQKPU=",
       "dev": true
     },
     "pullstream": {
@@ -6586,10 +2395,10 @@
       "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
       "dev": true,
       "requires": {
-        "over": "0.0.5",
-        "readable-stream": "1.0.34",
-        "setimmediate": "1.0.5",
-        "slice-stream": "1.0.0"
+        "over": ">= 0.0.5 < 1",
+        "readable-stream": "~1.0.31",
+        "setimmediate": ">= 1.0.2 < 2",
+        "slice-stream": ">= 1.0.0 < 2"
       },
       "dependencies": {
         "isarray": {
@@ -6604,10 +2413,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -6624,8 +2433,8 @@
       "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -6634,9 +2443,9 @@
       "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.0",
-        "inherits": "2.0.3",
-        "pump": "1.0.2"
+        "duplexify": "^3.1.2",
+        "inherits": "^2.0.1",
+        "pump": "^1.0.0"
       }
     },
     "punycode": {
@@ -6658,8 +2467,8 @@
       "dev": true,
       "requires": {
         "buffer-equal": "0.0.1",
-        "minimist": "1.2.0",
-        "through2": "2.0.3"
+        "minimist": "^1.1.3",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -6668,56 +2477,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
-      }
-    },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "optional": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "optional": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
-        }
-      }
-    },
-    "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "rc": {
@@ -6726,10 +2485,10 @@
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -6740,170 +2499,19 @@
         }
       }
     },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "dev": true,
-      "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
-      }
-    },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
-      }
-    },
-    "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
-    },
-    "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-    },
-    "regenerator-transform": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
-        "private": "0.1.7"
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "optional": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
-      }
-    },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
-    "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.1"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "requires": {
-        "jsesc": "0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-        }
-      }
-    },
-    "relative-url": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
-      "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc=",
-      "dev": true
-    },
-    "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "optional": true
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "request": {
@@ -6912,28 +2520,28 @@
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.16",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~4.2.1",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "performance-now": "^0.2.0",
+        "qs": "~6.4.0",
+        "safe-buffer": "^5.0.1",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.0.0"
       },
       "dependencies": {
         "qs": {
@@ -6950,25 +2558,13 @@
         }
       }
     },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
-    },
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "rimraf": {
@@ -6983,8 +2579,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rsa-pem-to-jwk": {
@@ -6993,7 +2589,7 @@
       "integrity": "sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=",
       "dev": true,
       "requires": {
-        "object-assign": "2.1.1",
+        "object-assign": "^2.0.0",
         "rsa-unpack": "0.0.6"
       },
       "dependencies": {
@@ -7011,25 +2607,14 @@
       "integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
       "dev": true,
       "requires": {
-        "optimist": "0.3.7"
+        "optimist": "~0.3.5"
       }
-    },
-    "run-parallel-limit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.0.3.tgz",
-      "integrity": "sha1-bDkwzHwLR9Na50IBCfZgqt4kAeM=",
-      "dev": true
-    },
-    "run-series": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-      "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
-      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "sandwich-stream": {
       "version": "1.0.0",
@@ -7043,15 +2628,15 @@
       "integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
       "dev": true,
       "requires": {
-        "bindings": "1.3.0",
-        "bip66": "1.1.5",
-        "bn.js": "4.11.6",
-        "create-hash": "1.1.3",
-        "drbg.js": "1.0.1",
-        "elliptic": "6.4.0",
-        "nan": "2.6.2",
-        "prebuild-install": "2.2.1",
-        "safe-buffer": "5.1.1"
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "prebuild-install": "^2.0.0",
+        "safe-buffer": "^5.1.0"
       }
     },
     "semver": {
@@ -7059,26 +2644,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "5.4.1"
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "optional": true
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -7092,16 +2662,7 @@
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
-      }
-    },
-    "sha3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.0.tgz",
-      "integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
-      "dev": true,
-      "requires": {
-        "nan": "2.6.2"
+        "inherits": "^2.0.1"
       }
     },
     "shallow-copy": {
@@ -7116,8 +2677,8 @@
       "integrity": "sha1-M1s+bhehI0LFSgVOp9mC06bFvzU=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "debug": "1.0.5"
+        "async": "^0.9.0",
+        "debug": "^1.0.2"
       },
       "dependencies": {
         "async": {
@@ -7149,7 +2710,7 @@
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
       "dev": true,
       "requires": {
-        "varint": "5.0.0"
+        "varint": "~5.0.0"
       }
     },
     "simple-get": {
@@ -7158,28 +2719,10 @@
       "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "unzip-response": "1.0.2",
-        "xtend": "4.0.1"
+        "once": "^1.3.1",
+        "unzip-response": "^1.0.0",
+        "xtend": "^4.0.0"
       }
-    },
-    "simple-peer": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-6.4.4.tgz",
-      "integrity": "sha1-TkIfSFrHsTsIB3pEdpNNUsW6O7M=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "get-browser-rtc": "1.0.2",
-        "inherits": "2.0.3",
-        "randombytes": "2.0.5",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-stream": {
       "version": "1.0.0",
@@ -7187,7 +2730,7 @@
       "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.31"
       },
       "dependencies": {
         "isarray": {
@@ -7202,10 +2745,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -7216,19 +2759,13 @@
         }
       }
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -7239,221 +2776,12 @@
         }
       }
     },
-    "socket.io": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
-      "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
-      "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "engine.io": "1.8.4",
-        "has-binary": "0.1.7",
-        "object-assign": "4.1.0",
-        "socket.io-adapter": "0.5.0",
-        "socket.io-client": "1.7.4",
-        "socket.io-parser": "2.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-          "dev": true
-        }
-      }
-    },
-    "socket.io-adapter": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
-      "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
-      "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "socket.io-parser": "2.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
-    "socket.io-client": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
-      "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
-      "dev": true,
-      "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "2.3.3",
-        "engine.io-client": "1.8.4",
-        "has-binary": "0.1.7",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "2.3.1",
-        "to-array": "0.1.4"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
-      "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
-      "dev": true,
-      "requires": {
-        "component-emitter": "1.1.2",
-        "debug": "2.2.0",
-        "isarray": "0.0.1",
-        "json3": "3.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "solidity-sha3": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/solidity-sha3/-/solidity-sha3-0.4.1.tgz",
-      "integrity": "sha1-F1d+k/bP1YSJxOx/LaMEdTAynsE=",
-      "requires": {
-        "babel-cli": "6.24.1",
-        "babel-preset-es2015": "6.24.1",
-        "babel-register": "6.24.1",
-        "left-pad": "1.1.3",
-        "web3": "0.16.0"
-      },
-      "dependencies": {
-        "web3": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-          "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
-          "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xmlhttprequest": "1.8.0"
-          }
-        }
-      }
-    },
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
-    },
-    "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "requires": {
-        "source-map": "0.5.6"
-      }
-    },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true,
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
-    },
-    "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
-    },
-    "spdy-transport": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
-      "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "wbuf": "1.7.2"
-      }
+      "optional": true
     },
     "split2": {
       "version": "2.1.1",
@@ -7461,14 +2789,8 @@
       "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
-    },
-    "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
-      "dev": true
     },
     "sshpk": {
       "version": "1.13.1",
@@ -7476,14 +2798,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.0",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -7513,7 +2835,7 @@
       "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
       "dev": true,
       "requires": {
-        "escodegen": "0.0.28"
+        "escodegen": "~0.0.24"
       },
       "dependencies": {
         "escodegen": {
@@ -7522,9 +2844,9 @@
           "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
           "dev": true,
           "requires": {
-            "esprima": "1.0.4",
-            "estraverse": "1.3.2",
-            "source-map": "0.5.6"
+            "esprima": "~1.0.2",
+            "estraverse": "~1.3.0",
+            "source-map": ">= 0.1.2"
           }
         },
         "esprima": {
@@ -7547,17 +2869,17 @@
       "integrity": "sha1-vvDZtviVhfbyNZuBYb7qsGBV29I=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "duplexer2": "0.0.2",
-        "escodegen": "1.3.3",
-        "falafel": "2.1.0",
-        "has": "1.0.1",
-        "object-inspect": "0.4.0",
-        "quote-stream": "0.0.0",
-        "readable-stream": "1.0.34",
-        "shallow-copy": "0.0.1",
-        "static-eval": "0.2.4",
-        "through2": "0.4.2"
+        "concat-stream": "~1.6.0",
+        "duplexer2": "~0.0.2",
+        "escodegen": "~1.3.2",
+        "falafel": "^2.1.0",
+        "has": "^1.0.0",
+        "object-inspect": "~0.4.0",
+        "quote-stream": "~0.0.0",
+        "readable-stream": "~1.0.27-1",
+        "shallow-copy": "~0.0.1",
+        "static-eval": "~0.2.0",
+        "through2": "~0.4.1"
       },
       "dependencies": {
         "isarray": {
@@ -7579,7 +2901,7 @@
           "dev": true,
           "requires": {
             "minimist": "0.0.8",
-            "through2": "0.4.2"
+            "through2": "~0.4.1"
           }
         },
         "readable-stream": {
@@ -7588,10 +2910,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -7606,8 +2928,8 @@
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -7616,7 +2938,7 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -7627,11 +2949,11 @@
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -7640,43 +2962,11 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "stream-to-pull-stream": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
-      "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
-      "dev": true,
-      "requires": {
-        "looper": "3.0.0",
-        "pull-stream": "3.6.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k=",
-          "dev": true
-        }
-      }
-    },
     "streamifier": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
       "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
       "dev": true
-    },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
     },
     "string-width": {
       "version": "1.0.2",
@@ -7684,9 +2974,18 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -7699,15 +2998,10 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
     },
     "strip-hex-prefix": {
       "version": "1.0.0",
@@ -7730,14 +3024,9 @@
       "dev": true,
       "requires": {
         "comandante": "0.0.1",
-        "duplexer": "0.1.1",
-        "is-running": "1.0.5"
+        "duplexer": "^0.1.1",
+        "is-running": "^1.0.5"
       }
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tar-fs": {
       "version": "1.15.3",
@@ -7745,10 +3034,10 @@
       "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
       "dev": true,
       "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.2",
-        "tar-stream": "1.5.4"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       }
     },
     "tar-stream": {
@@ -7757,10 +3046,10 @@
       "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "temp": {
@@ -7769,8 +3058,8 @@
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
       }
     },
     "through2": {
@@ -7779,27 +3068,9 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
-    },
-    "timed-out": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-      "dev": true
-    },
-    "timed-tape": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/timed-tape/-/timed-tape-0.1.1.tgz",
-      "integrity": "sha1-m25WnxfmbHnx7tLSX/eWL8dBjkk=",
-      "dev": true
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
-      "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -7807,63 +3078,39 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-    },
-    "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle-artifactor": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/truffle-artifactor/-/truffle-artifactor-2.1.5.tgz",
       "integrity": "sha1-k51sszOYS1ZSmFDgPD3aykkAaHA=",
       "requires": {
-        "async": "1.5.2",
-        "fs-extra": "1.0.0",
-        "lodash": "4.17.4",
-        "truffle-contract": "2.0.4",
-        "truffle-contract-schema": "0.0.5"
+        "async": "^1.5.2",
+        "fs-extra": "^1.0.0",
+        "lodash": "^4.11.2",
+        "truffle-contract": "^2.0.3",
+        "truffle-contract-schema": "^0.0.5"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "fs-extra": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         },
         "truffle-contract": {
@@ -7872,9 +3119,9 @@
           "integrity": "sha1-wjxOr2Y5eSe6uHUbZ0FJw/i5M+s=",
           "requires": {
             "ethjs-abi": "0.1.8",
-            "truffle-blockchain-utils": "0.0.3",
-            "truffle-contract-schema": "0.0.5",
-            "web3": "0.20.1"
+            "truffle-blockchain-utils": "^0.0.3",
+            "truffle-contract-schema": "^0.0.5",
+            "web3": "^0.20.1"
           }
         },
         "web3": {
@@ -7882,11 +3129,11 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.1.tgz",
           "integrity": "sha1-+yYumtcVUhZ6avAS/dQg3gFwMvA=",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xhr2": "0.1.4",
-            "xmlhttprequest": "1.8.0"
+            "bignumber.js": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
           }
         }
       }
@@ -7896,22 +3143,23 @@
       "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.3.tgz",
       "integrity": "sha1-rooRHsEk2WUE8OBCxvIFwLOBfik=",
       "requires": {
-        "web3": "0.20.1"
+        "web3": "^0.20.1"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "web3": {
           "version": "0.20.1",
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.1.tgz",
           "integrity": "sha1-+yYumtcVUhZ6avAS/dQg3gFwMvA=",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xhr2": "0.1.4",
-            "xmlhttprequest": "1.8.0"
+            "bignumber.js": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
           }
         }
       }
@@ -7924,18 +3172,19 @@
         "ethjs-abi": "0.1.8",
         "truffle-blockchain-utils": "0.0.1",
         "truffle-contract-schema": "0.0.5",
-        "web3": "0.16.0"
+        "web3": "^0.16.0"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
         },
         "truffle-blockchain-utils": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.1.tgz",
           "integrity": "sha1-B6WOVbsFVaZCCMkRnAsE/+FGSqQ=",
           "requires": {
-            "web3": "0.18.4"
+            "web3": "^0.18.0"
           },
           "dependencies": {
             "web3": {
@@ -7944,10 +3193,10 @@
               "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
               "requires": {
                 "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-                "crypto-js": "3.1.8",
-                "utf8": "2.1.2",
-                "xhr2": "0.1.4",
-                "xmlhttprequest": "1.8.0"
+                "crypto-js": "^3.1.4",
+                "utf8": "^2.1.1",
+                "xhr2": "*",
+                "xmlhttprequest": "*"
               }
             }
           }
@@ -7957,14 +3206,15 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xmlhttprequest": "1.8.0"
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#master",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xmlhttprequest": "*"
           },
           "dependencies": {
             "bignumber.js": {
-              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+              "from": "git+https://github.com/debris/bignumber.js.git#master"
             }
           }
         }
@@ -7975,7 +3225,7 @@
       "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-0.0.5.tgz",
       "integrity": "sha1-Xp0gvQvyon/pQxB0gknUhO7kmWE=",
       "requires": {
-        "crypto-js": "3.1.9-1"
+        "crypto-js": "^3.1.9-1"
       },
       "dependencies": {
         "crypto-js": {
@@ -7989,7 +3239,8 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
       "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "tunnel": {
       "version": "0.0.2",
@@ -8003,7 +3254,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -8012,31 +3263,10 @@
       "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
       "dev": true
     },
-    "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-      "dev": true
-    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
-      "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
-      "dev": true,
-      "requires": {
-        "is-typedarray": "1.0.0"
-      }
-    },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
     },
     "unzip": {
@@ -8045,12 +3275,12 @@
       "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
       "dev": true,
       "requires": {
-        "binary": "0.3.0",
-        "fstream": "0.1.31",
-        "match-stream": "0.0.2",
-        "pullstream": "0.4.1",
-        "readable-stream": "1.0.34",
-        "setimmediate": "1.0.5"
+        "binary": ">= 0.3.0 < 1",
+        "fstream": ">= 0.1.30 < 1",
+        "match-stream": ">= 0.0.2 < 1",
+        "pullstream": ">= 0.4.1 < 1",
+        "readable-stream": "~1.0.31",
+        "setimmediate": ">= 1.0.1 < 2"
       },
       "dependencies": {
         "isarray": {
@@ -8065,10 +3295,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -8085,36 +3315,6 @@
       "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
       "dev": true
     },
-    "update-notifier": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
-      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
-      "dev": true,
-      "requires": {
-        "boxen": "0.6.0",
-        "chalk": "1.1.3",
-        "configstore": "2.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "2.0.0",
-        "lazy-req": "1.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "2.0.0"
-      }
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
-    },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
-    },
     "utf8": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
@@ -8123,31 +3323,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "v8flags": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "requires": {
-        "user-home": "1.1.1"
-      }
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
     },
     "varint": {
       "version": "5.0.0",
@@ -8164,29 +3341,21 @@
         "extsprintf": "1.0.2"
       }
     },
-    "wbuf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
-      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-      "dev": true,
-      "requires": {
-        "minimalistic-assert": "1.0.0"
-      }
-    },
     "web3": {
       "version": "0.18.4",
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
       "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
       "requires": {
         "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-        "crypto-js": "3.1.8",
-        "utf8": "2.1.2",
-        "xhr2": "0.1.4",
-        "xmlhttprequest": "1.8.0"
+        "crypto-js": "^3.1.4",
+        "utf8": "^2.1.1",
+        "xhr2": "*",
+        "xmlhttprequest": "*"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
         }
       }
     },
@@ -8197,12 +3366,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "@types/node": "6.0.85",
-        "tslib": "1.7.1"
+        "@types/node": "^6",
+        "tslib": "^1.5.0"
       }
     },
     "webcrypto-shim": {
       "version": "github:dignifiedquire/webcrypto-shim#effe03d3401ccbfb4837191bc393bb347e0c0f0a",
+      "from": "webcrypto-shim@github:dignifiedquire/webcrypto-shim#effe03d3401ccbfb4837191bc393bb347e0c0f0a",
       "dev": true
     },
     "wget-improved": {
@@ -8223,28 +3393,13 @@
         }
       }
     },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
-    },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
-      }
-    },
-    "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "wordwrap": {
@@ -8253,56 +3408,11 @@
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
-      }
-    },
-    "ws": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
-      "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
-      "dev": true,
-      "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
-      }
-    },
-    "wtf-8": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
-      "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
     },
     "xhr2": {
       "version": "0.1.4",
@@ -8314,153 +3424,16 @@
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
-      "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
-      "dev": true
-    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
-    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
-    },
-    "yargs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-      "dev": true,
-      "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-      "dev": true,
-      "requires": {
-        "camelcase": "3.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
-      }
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
   },
   "dependencies": {
     "fs-extra": "^2.0.0",
-    "left-pad": "^1.1.3",
     "semver": "^5.3.0",
-    "solidity-sha3": "^0.4.1",
     "truffle-artifactor": "^2.1.2",
     "truffle-contract": "^1.1.6",
     "web3": "^0.18.2"


### PR DESCRIPTION
Hello! I just thought I'd submit a handy PR remove the unused "left-pad" and "solidity-sha3" packages. This PR also updates the package-lock file, which appears to have been stale for a little while.

I'm having trouble running the tests though, is there any documentation available on this, or could one of the maintainers run them on my behalf?